### PR TITLE
Fixed outline export

### DIFF
--- a/misc/glb_factory.py
+++ b/misc/glb_factory.py
@@ -431,10 +431,10 @@ class GlbObj:
                 float_val = get_float_value(mtoon_shader_node, float_prop)
                 if float_val is not None:
                     mtoon_float_dic[float_key] = float_val
-                    if float_key == "OutlineWidthMode":
+                    if float_key == "_OutlineWidthMode":
                         outline_width_mode = min(max(round(float_val), 0), 2)
                         mtoon_float_dic[float_key] = int(outline_width_mode)
-                    if float_key == "OutlineColorMode":
+                    if float_key == "_OutlineColorMode":
                         outline_color_mode = min(max(round(float_val), 0), 1)
                         mtoon_float_dic[float_key] = int(outline_color_mode)
 


### PR DESCRIPTION
The outline export used the wrong names to identify the outline properties, resulting in having an outline mode always equal to 0, this no exported models had any outlines. I corrected the names and now the outlines are exported correctly.