### PR TITLE
Check for active object before switching to object mode

### DIFF
--- a/io_scene_vrm/exporter/glb_obj.py
+++ b/io_scene_vrm/exporter/glb_obj.py
@@ -1322,7 +1322,9 @@ class GlbObj:
                 ] = self.axis_blender_to_glb(relate_pos)
 
             # region hell
-            bpy.ops.object.mode_set(mode="OBJECT")
+            # Check added to resolve https://github.com/saturday06/VRM_Addon_for_Blender/issues/70
+            if bpy.context.view_layer.objects.active is not None:
+                bpy.ops.object.mode_set(mode="OBJECT")
 
             # region glTF-Blender-IO
             # https://github.com/KhronosGroup/glTF-Blender-IO/blob/blender-v2.91-release/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py#L285-L303


### PR DESCRIPTION
When the exporter iterates through each mesh to export, it needs to enter edit mode to work with the mesh data.
Before this must happen, we must enter object mode so we can pick the mesh we want to use.

However, in some cases, there will be no mesh selected - causing mode_set() to fail, as there is no active object, causing a crash.
This fixes this crash by just not bothering to switch into object mode if nothing is selected, as it's a redundant operation at that point.

Additionally, blender safeguards against misbehavior here - if you try to deselect `bpy.context.view_layer.objects.active` by setting it to none while in any mode other than object mode, it kicks you back into object mode, allowing you to select a new mesh.

Fixes #70