### PR TITLE
Implement emissive strength for PBR materials

### DIFF
--- a/io_scene_vrm/exporter/legacy_vrm_exporter.py
+++ b/io_scene_vrm/exporter/legacy_vrm_exporter.py
@@ -1059,6 +1059,8 @@ class LegacyVrmExporter(AbstractBaseVrmExporter):
                         b_mat, not b_mat.use_backface_culling, export_settings
                     )
 
+                pbr_dict["extensions"] = {}
+
                 alpha_cutoff = getattr(gltf2_io_material, "alpha_cutoff", None)
                 if isinstance(alpha_cutoff, (int, float)):
                     pbr_dict["alphaCutoff"] = alpha_cutoff
@@ -1089,7 +1091,18 @@ class LegacyVrmExporter(AbstractBaseVrmExporter):
                     and extensions.get("KHR_materials_unlit") is not None
                 ):
                     # https://github.com/KhronosGroup/glTF/tree/19a1d820040239bca1327fc26220ae8cae9f948c/extensions/2.0/Khronos/KHR_materials_unlit
-                    pbr_dict["extensions"] = {"KHR_materials_unlit": {}}
+                    pbr_dict["extensions"]["KHR_materials_unlit"] = {}
+
+
+                if emissive_factor is not None:
+                    emissive_strength = b_mat.node_tree.nodes['Principled BSDF'].inputs['Emission Strength'].default_value
+                    hdr_emissive_factor = Vector((
+                        emissive_factor[0] * emissive_strength,
+                        emissive_factor[1] * emissive_strength,
+                        emissive_factor[2] * emissive_strength,
+                    ))
+                    pbr_dict["emissiveFactor"] = list(hdr_emissive_factor)
+                    pbr_dict["extensions"]["KHR_materials_emissive_strength"] = { "emissiveStrength": emissive_strength  }
 
                 assign_dict(
                     pbr_dict,

--- a/io_scene_vrm/exporter/legacy_vrm_exporter.py
+++ b/io_scene_vrm/exporter/legacy_vrm_exporter.py
@@ -1093,15 +1093,8 @@ class LegacyVrmExporter(AbstractBaseVrmExporter):
                     # https://github.com/KhronosGroup/glTF/tree/19a1d820040239bca1327fc26220ae8cae9f948c/extensions/2.0/Khronos/KHR_materials_unlit
                     pbr_dict["extensions"]["KHR_materials_unlit"] = {}
 
-
                 if emissive_factor is not None:
                     emissive_strength = b_mat.node_tree.nodes['Principled BSDF'].inputs['Emission Strength'].default_value
-                    hdr_emissive_factor = Vector((
-                        emissive_factor[0] * emissive_strength,
-                        emissive_factor[1] * emissive_strength,
-                        emissive_factor[2] * emissive_strength,
-                    ))
-                    pbr_dict["emissiveFactor"] = list(hdr_emissive_factor)
                     pbr_dict["extensions"]["KHR_materials_emissive_strength"] = { "emissiveStrength": emissive_strength  }
 
                 assign_dict(


### PR DESCRIPTION
This PR adds support for exporting emissive strength/intensity on PBR materials in VRM via the `KHR_materials_emissive_strength` extension.

https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength

Our users want to use HDR bloom so that parts of their avatar glow like this:

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/760516/215009016-6d49eac6-2fd7-4127-8168-f6b863dba0b8.png">

While the code works, i'm not entirely familiar with python or blender plugins so happy to improve this based on any feedback you may have.