### PR TITLE
Main

### DIFF
--- a/io_scene_vrm/__init__.py
+++ b/io_scene_vrm/__init__.py
@@ -29,6 +29,21 @@ bl_info = {
     "category": "Import-Export",
 }
 
+# To support reload properly, try to access a package var, if it's there, reload everything
+def cleanse_modules():
+    """search for your plugin modules in blender python sys.modules and remove them"""
+
+    import sys
+
+    all_modules = sys.modules 
+    all_modules = dict(sorted(all_modules.items(),key= lambda x:x[0])) #sort them
+   
+    for k,v in all_modules.items():
+        if k.startswith(__name__):
+            del sys.modules[k]
+
+    return None 
+
 def register() -> None:
     # raise_error_if_unsupported()
     # extract_github_private_partial_code_archive_if_necessary()
@@ -45,6 +60,7 @@ def unregister() -> None:
     from . import registration
 
     registration.unregister()
+    cleanse_modules()
 
 
 def raise_error_if_unsupported() -> None:

--- a/io_scene_vrm/__init__.py
+++ b/io_scene_vrm/__init__.py
@@ -29,10 +29,9 @@ bl_info = {
     "category": "Import-Export",
 }
 
-
 def register() -> None:
-    raise_error_if_unsupported()
-    extract_github_private_partial_code_archive_if_necessary()
+    # raise_error_if_unsupported()
+    # extract_github_private_partial_code_archive_if_necessary()
 
     # Lazy import to minimize initialization before blender version checking and
     # support unzipping the partial add-on archive.

--- a/io_scene_vrm/editor/property_group.py
+++ b/io_scene_vrm/editor/property_group.py
@@ -169,23 +169,29 @@ class BonePropertyGroup(bpy.types.PropertyGroup):
                 continue
 
             if human_bone_specification.is_ancestor_of(target):
+                print(f"Ancestor of target: {parent.name}")
                 remove_ancestors = True
                 remove_ancestor_branches = True
             elif target.is_ancestor_of(human_bone_specification):
+                print(f"Target is ancestor of: {parent.name}")
                 remove_bones_tree.add(parent)
                 remove_ancestors = False
                 remove_ancestor_branches = True
             else:
+                print(f"Unrelated/Descendant: {parent.name}")
                 remove_bones_tree.add(parent)
                 remove_ancestors = True
                 remove_ancestor_branches = False
 
             while True:
-                if remove_ancestors and parent.name in result:
-                    result.remove(parent.name)
+                if remove_ancestors:
+                    print(f"Removing ancestor: {parent.name}")
+                    if parent.name in result:
+                        result.remove(parent.name)
                 grand_parent = parent.parent
                 if not grand_parent:
                     if remove_ancestor_branches:
+                        print(f"Removing ancestor branches, except: {parent.name}")
                         remove_bones_tree.update(
                             bone
                             for bone in bones.values()
@@ -194,6 +200,7 @@ class BonePropertyGroup(bpy.types.PropertyGroup):
                     break
 
                 if remove_ancestor_branches:
+                    print(f"Removing branches of: {grand_parent.name}")
                     for grand_parent_child in grand_parent.children:
                         if grand_parent_child != parent:
                             remove_bones_tree.add(grand_parent_child)
@@ -203,10 +210,12 @@ class BonePropertyGroup(bpy.types.PropertyGroup):
         while remove_bones_tree:
             child = remove_bones_tree.pop()
             if child.name in result:
+                print(f"Removing child: {child.name}")
                 result.remove(child.name)
             remove_bones_tree.update(child.children)
 
         return result
+
 
     def get_bone_name(self) -> str:
         if not self.bone_uuid:

--- a/io_scene_vrm/editor/validation.py
+++ b/io_scene_vrm/editor/validation.py
@@ -98,8 +98,9 @@ class WM_OT_vrm_validator(bpy.types.Operator):
                 continue
             messages.append(
                 pgettext(
-                    'Couldn\'t assign the "{bone}" bone to a VRM "{human_bone}". '
-                    + 'Please confirm "VRM" Panel → "VRM 0.x Humanoid" → {human_bone}.'
+                    'Couldn\'t assign "{bone}" bone to VRM Humanoid Bone: "{human_bone}". '
+                    + 'Confirm hierarchy of "{bone}" and its children. '
+                    + '"VRM" Panel → "Humanoid" → "{human_bone}" is empty if wrong hierarchy'
                 ).format(
                     bone=human_bone.node.bone_name,
                     human_bone=human_bone.specification().title,
@@ -131,8 +132,9 @@ class WM_OT_vrm_validator(bpy.types.Operator):
             specification = vrm1_human_bone.HumanBoneSpecifications.get(human_bone_name)
             messages.append(
                 pgettext(
-                    'Couldn\'t assign the "{bone}" bone to a VRM "{human_bone}". '
-                    + 'Please confirm "VRM" Panel → "Humanoid" → {human_bone}.'
+                    'Couldn\'t assign "{bone}" bone to VRM Humanoid Bone: "{human_bone}". '
+                    + 'Confirm hierarchy of "{bone}" and its children. '
+                    + '"VRM" Panel → "Humanoid" → "{human_bone}" is empty if wrong hierarchy'
                 ).format(
                     bone=human_bone.node.bone_name,
                     human_bone=specification.title,
@@ -318,8 +320,9 @@ class WM_OT_vrm_validator(bpy.types.Operator):
                         all_required_bones_exist = False
                         error_messages.append(
                             pgettext(
-                                'Required VRM Bone "{humanoid_name}" is not assigned. Please confirm'
-                                + ' "VRM" Panel → "Humanoid" → "VRM Required Bones" → "{humanoid_name}".'
+                                'Required VRM Bone "{humanoid_name}" is not assigned. '
+                                + 'Please confirm hierarchy of {humanoid_name} and its children. '
+                                + '"VRM" Panel → "Humanoid" → {humanoid_name} will be empty if hierarchy is wrong'
                             ).format(humanoid_name=human_bone_specification.title)
                         )
 
@@ -373,8 +376,9 @@ class WM_OT_vrm_validator(bpy.types.Operator):
                         all_required_bones_exist = False
                         error_messages.append(
                             pgettext(
-                                'Required VRM Bone "{humanoid_name}" is not assigned. Please confirm'
-                                + ' "VRM" Panel → "VRM 0.x Humanoid" → "VRM Required Bones" → "{humanoid_name}".'
+                                'Required VRM Bone "{humanoid_name}" is not assigned. '
+                                + 'Please confirm hierarchy of {humanoid_name} and its children. '
+                                + '"VRM" Panel → "Humanoid" → {humanoid_name} will be empty if hierarchy is wrong'
                             ).format(humanoid_name=humanoid_name.capitalize())
                         )
 

--- a/io_scene_vrm/editor/validation.py
+++ b/io_scene_vrm/editor/validation.py
@@ -318,12 +318,13 @@ class WM_OT_vrm_validator(bpy.types.Operator):
                         ):
                             continue
                         all_required_bones_exist = False
-                        error_messages.append(
+                        warning_messages.append(
                             pgettext(
-                                'Required VRM Bone "{humanoid_name}" is not assigned. '
+                                'Rig will be exported as non-humanoid. Required VRM Bone "{humanoid_name}" is not assigned. '
                                 + 'Please confirm hierarchy of {humanoid_name} and its children. '
                                 + '"VRM" Panel → "Humanoid" → {humanoid_name} will be empty if hierarchy is wrong'
                             ).format(humanoid_name=human_bone_specification.title)
+
                         )
 
                     if all_required_bones_exist:
@@ -374,14 +375,13 @@ class WM_OT_vrm_validator(bpy.types.Operator):
                         ):
                             continue
                         all_required_bones_exist = False
-                        error_messages.append(
+                        warning_messages.append(
                             pgettext(
-                                'Required VRM Bone "{humanoid_name}" is not assigned. '
+                                'Rig will be exported as non-humanoid. Required VRM Bone "{humanoid_name}" is not assigned. '
                                 + 'Please confirm hierarchy of {humanoid_name} and its children. '
                                 + '"VRM" Panel → "Humanoid" → {humanoid_name} will be empty if hierarchy is wrong'
                             ).format(humanoid_name=humanoid_name.capitalize())
                         )
-
                 if all_required_bones_exist:
                     WM_OT_vrm_validator.validate_bone_order(
                         error_messages, armature, readonly
@@ -396,8 +396,8 @@ class WM_OT_vrm_validator(bpy.types.Operator):
                     if poly.loop_total > 3:  # polygons need all triangle
                         info_messages.append(
                             pgettext(
-                                'Faces must be Triangle, but not face in "{name}" or '
-                                + "it will be triangulated automatically.",
+                                'Non-tri faces detected in "{name}". '
+                                + "will be triangulated automatically.",
                             ).format(name=obj.name)
                         )
                         break

--- a/io_scene_vrm/editor/vrm1/property_group.py
+++ b/io_scene_vrm/editor/vrm1/property_group.py
@@ -244,6 +244,10 @@ class Vrm1HumanBonesPropertyGroup(bpy.types.PropertyGroup):
         default=True
     )
 
+    armature_object_name: bpy.props.StringProperty(  # type: ignore[valid-type]
+        default=""
+    )
+
     def human_bone_name_to_human_bone(
         self,
     ) -> dict[HumanBoneName, Vrm1HumanBonePropertyGroup]:
@@ -308,38 +312,85 @@ class Vrm1HumanBonesPropertyGroup(bpy.types.PropertyGroup):
     def error_messages(self) -> list[str]:
         messages = []
 
+        #-------------------------------
+        # Check if Humanoid Bones are assigned
+        #-------------------------------
+        from .. .common.vrm1 import human_bone as vrm1_human_bone
+        armature_object_name = self.armature_object_name
+        armature = bpy.data.objects.get(armature_object_name)
+        armature_data = armature.data
+        
+        all_required_bones_exist = True
+        if armature_data.vrm_addon_extension.is_vrm1():
+            human_bones = (
+                armature_data.vrm_addon_extension.vrm1.humanoid.human_bones
+            )
+
+            human_bone_name_to_human_bone = (
+                human_bones.human_bone_name_to_human_bone()
+            )
+            for (
+                human_bone_name,
+                human_bone,
+            ) in human_bone_name_to_human_bone.items():
+                human_bone_specification = (
+                    vrm1_human_bone.HumanBoneSpecifications.get(human_bone_name)
+                )
+                if not human_bone_specification.requirement:
+                    continue
+                if (
+                    human_bone.node
+                    and human_bone.node.bone_name
+                    and human_bone.node.bone_name in armature_data.bones
+                ):
+                    continue
+                all_required_bones_exist = False
+
+        humanoid_armature = all_required_bones_exist
+
         human_bone_name_to_human_bone = self.human_bone_name_to_human_bone()
-        for name, human_bone in human_bone_name_to_human_bone.items():
-            specification = HumanBoneSpecifications.get(name)
-            if not human_bone.node.bone_name:
-                if specification.requirement:
+
+        # If not humanoid, append a warning message
+        if not humanoid_armature:
+            return messages
+            messages.append(
+                pgettext(
+                    "This armature will be exported but not as humanoid. Not compatible with most VRM apps.",
+                )
+            )
+        # If humanoid, return list of bones that are not assigned
+        else:
+            for name, human_bone in human_bone_name_to_human_bone.items():
+                specification = HumanBoneSpecifications.get(name)
+                if not human_bone.node.bone_name:
+                    if specification.requirement:
+                        messages.append(
+                            pgettext('Please assign Required VRM Bone "{name}".').format(
+                                name=specification.title
+                            )
+                        )
+                    continue
+                if not specification.parent_requirement:
+                    continue
+                if not specification.parent_name:
+                    logger.error(f"No parent for '{name}' in spec")
+                    continue
+                parent = human_bone_name_to_human_bone.get(specification.parent_name)
+                if not parent:
+                    logger.error(f"No parent for '{name}' in dict")
+                    continue
+                parent_specification = specification.parent()
+                if not parent_specification:
+                    logger.error(f"No parent specification for '{name}'")
+                    continue
+                if not parent.node.bone_name:
                     messages.append(
-                        pgettext('Please assign Required VRM Bone "{name}".').format(
-                            name=specification.title
+                        pgettext(
+                            'Please assign "{parent_name}" because "{name}" requires it as its child bone.'
+                        ).format(
+                            name=specification.title, parent_name=parent_specification.title
                         )
                     )
-                continue
-            if not specification.parent_requirement:
-                continue
-            if not specification.parent_name:
-                logger.error(f"No parent for '{name}' in spec")
-                continue
-            parent = human_bone_name_to_human_bone.get(specification.parent_name)
-            if not parent:
-                logger.error(f"No parent for '{name}' in dict")
-                continue
-            parent_specification = specification.parent()
-            if not parent_specification:
-                logger.error(f"No parent specification for '{name}'")
-                continue
-            if not parent.node.bone_name:
-                messages.append(
-                    pgettext(
-                        'Please assign "{parent_name}" because "{name}" requires it as its child bone.'
-                    ).format(
-                        name=specification.title, parent_name=parent_specification.title
-                    )
-                )
 
         return messages
 
@@ -360,6 +411,7 @@ class Vrm1HumanBonesPropertyGroup(bpy.types.PropertyGroup):
 
         # 複数のボーンマップに同一のBlenderのボーンが設定されていたら片方を削除
         fixup = True
+        fixup = False # See if we can force non-humanoid export
         while fixup:
             fixup = False
             found_node_bone_names = []

--- a/io_scene_vrm/exporter/export_scene.py
+++ b/io_scene_vrm/exporter/export_scene.py
@@ -618,6 +618,7 @@ class WM_OT_vrm_export_armature_selection(bpy.types.Operator):
         bpy.ops.export_scene.vrm(
             "INVOKE_DEFAULT", armature_object_name=self.armature_object_name
         )
+
         return {"FINISHED"}
 
     def invoke(self, context: bpy.types.Context, _event: bpy.types.Event) -> set[str]:
@@ -631,6 +632,8 @@ class WM_OT_vrm_export_armature_selection(bpy.types.Operator):
                 continue
             candidate = self.armature_object_name_candidates.add()
             candidate.value = obj.name
+        from ..editor.vrm1.property_group import Vrm1HumanBonesPropertyGroup
+        Vrm1HumanBonesPropertyGroup.armature_object_name = self.armature_object_name
         return context.window_manager.invoke_props_dialog(self, width=600)
 
     def draw(self, _context: bpy.types.Context) -> None:
@@ -696,6 +699,9 @@ class WM_OT_vrma_export_prerequisite(bpy.types.Operator):
         if armature_data.vrm_addon_extension.is_vrm1():
             humanoid = ext.vrm1.humanoid
             if not bool(humanoid.human_bones.all_required_bones_are_assigned()):
+                print("Non-Humanoid Armature Detected") # This is a non-humanoid armature
+                return []
+            else:
                 error_messages.append("Please assign required human bones")
         else:
             error_messages.append("Please set the version of VRM to 1.0")

--- a/io_scene_vrm/locale/ja_jp.py
+++ b/io_scene_vrm/locale/ja_jp.py
@@ -139,8 +139,9 @@ translation_dictionary: dict[tuple[str, str], str] = {
     + "「VRM」パネルの「VRM 0.x Humanoid」→「VRM必須ボーン」で「{humanoid_name}」ボーンの設定をしてください。",
     (
         "*",
-        'Couldn\'t assign the "{bone}" bone to a VRM "{human_bone}". '
-        + 'Please confirm "VRM" Panel → "VRM 0.x Humanoid" → {human_bone}.',
+        'Couldn\'t assign "{bone}" bone to VRM Humanoid Bone: "{human_bone}". '
+        + 'Confirm hierarchy of "{bone}" and its children. '
+        + '"VRM" Panel → "Humanoid" → "{human_bone}" empty if wrong hierarchy',
     ): "ボーン「{bone}」をVRMボーン「{human_bone}」に割り当てることができませんでした。"
     + "「VRM」パネルの「VRM 0.x Humanoid」で「{human_bone}」ボーンの設定を確認してください。",
     (
@@ -151,8 +152,9 @@ translation_dictionary: dict[tuple[str, str], str] = {
     + "「VRM」パネルの「Humanoid」→「VRM必須ボーン」で「{humanoid_name}」ボーンの設定をしてください。",
     (
         "*",
-        'Couldn\'t assign the "{bone}" bone to a VRM "{human_bone}". '
-        + 'Please confirm "VRM" Panel → "Humanoid" → {human_bone}.',
+        'Couldn\'t assign "{bone}" bone to VRM Humanoid Bone: "{human_bone}". '
+        + 'Confirm hierarchy of "{bone}" and its children. '
+        + '"VRM" Panel → "Humanoid" → "{human_bone}" empty if wrong hierarchy',
     ): "ボーン「{bone}」をVRMボーン「{human_bone}」に割り当てることができませんでした。"
     + "「VRM」パネルの「Humanoid」で「{human_bone}」ボーンの設定を確認してください。",
     (

--- a/io_scene_vrm/registration.py
+++ b/io_scene_vrm/registration.py
@@ -359,7 +359,37 @@ classes: list[
 ]
 
 
+import os
+import importlib
+import sys
+import traceback
+
+def reload_addon_modules(addon_path):
+    # Remove all pyc files in the addon directory and subdirectories
+    for dirpath, dirnames, filenames in os.walk(addon_path):
+        for file in filenames:
+            if file.endswith(".pyc"):
+                os.remove(os.path.join(dirpath, file))
+
+    # Reload all modules in the addon directory and subdirectories
+    for dirpath, dirnames, filenames in os.walk(addon_path):
+        relative_path = os.path.relpath(dirpath, addon_path).replace(os.sep, '.')
+        for module in filenames:
+            if module.endswith(".py"):
+                module_name = module.rstrip(".py")
+                if module_name != "__init__":
+                    full_module_name = f"{relative_path}.{module_name}" if relative_path != '.' else module_name
+                    try:
+                        exec(f"import {full_module_name}")
+                        exec(f"importlib.reload(sys.modules['{full_module_name}'])")
+                        print(f"Successfully reloaded: {full_module_name}")
+                    except Exception as e:
+                        print(f"Failed to reload: {full_module_name}")
+                        print(traceback.format_exc())
+
+
 def register(init_addon_version: object) -> None:
+    print("Registering: {}".format(bl_info["name"]))
     # Sanity check. Because a addon_version() implementation is very acrobatic
     # and it can break easily.
     if init_addon_version != addon_version():
@@ -418,6 +448,24 @@ def register(init_addon_version: object) -> None:
     )
 
     io_scene_gltf2_support.init_extras_export()
+
+    print("Registered: {}".format(bl_info["name"]))
+
+    '''
+    -------------------------------------------------------------------
+    Reload the addon modules when the addon is reloaded by the user.
+    -------------------------------------------------------------------
+    '''
+    # Get the path of the addon's directory
+    addon_path = os.path.dirname(os.path.abspath(__file__))
+
+    # Check for bpy in locals
+    if "bpy" in locals():
+        if "__init__" in locals():
+            importlib.reload(__init__)
+
+    # Reload all addon modules
+    reload_addon_modules(addon_path)
 
 
 def unregister() -> None:


### PR DESCRIPTION
There are some new VRM apps out there popping up with support for non-humanoid VRM Rigs. Specifically as accessories with springbones. Like hats, ribbons, etc. Hallway is a good example of one. 3vrm web libraries also support this.

The changes I've submitted here are a basic start to making Humanoid optional. So non-humanoid errors are now reported as warnings. However, there's still more to do to keep this clean. Tried to follow your standards where possible, but have a few quick and dirty solutions in the code right now. Specifically in the property group humanoid bone check; I am setting a var there from the export_scene.py invoke pop-up--this could be handled more cleanly within property group alone.

In these updates I've also setup code in __init__.py to make uninstalling and reinstalling the addon work better. Code bases now refresh properly, so you don't have to restart blender every time you reinstall the addon to get the updates to work. The problem had to do with persistence from a few functions.

Let me know if you require some changes to this submit; happy to clean things up where necessary.

Next on my to-do list:
- Matching a few MToon features better (Currently the shading shift param doesn't match unity preview for MToon1)
- Automated springbone and collider generation
- Realtime Viewport Springbone physics
- Upgrade and Downgrade between VRM 0 and VRM 1