### PR TITLE
Fix spring bone gravity migration override

### DIFF
--- a/src/io_scene_vrm/editor/spring_bone1/migration.py
+++ b/src/io_scene_vrm/editor/spring_bone1/migration.py
@@ -21,6 +21,8 @@ def _migrate_blender_object(armature: Armature) -> None:
 
 def _fixup_gravity_dir(armature: Armature) -> None:
     ext = get_armature_extension(armature)
+    if tuple(ext.addon_version) == ext.INITIAL_ADDON_VERSION:
+        return
 
     if tuple(ext.addon_version) <= (2, 14, 3):
         for spring in ext.spring_bone1.springs:

--- a/src/io_scene_vrm/editor/vrm0/migration.py
+++ b/src/io_scene_vrm/editor/vrm0/migration.py
@@ -610,7 +610,9 @@ def _remove_link_to_mesh_object(armature_data: Armature) -> None:
 
 def _fixup_gravity_dir(armature_data: Armature) -> None:
     ext = get_armature_extension(armature_data)
-    if tuple(ext.addon_version) >= (2, 15, 4):
+    if tuple(ext.addon_version) == ext.INITIAL_ADDON_VERSION or tuple(
+        ext.addon_version
+    ) >= (2, 15, 4):
         return
 
     for bone_group in ext.vrm0.secondary_animation.bone_groups:

--- a/tests/editor/spring_bone1/test_ops.py
+++ b/tests/editor/spring_bone1/test_ops.py
@@ -9,6 +9,7 @@ from bpy.types import Armature
 from mathutils import Euler, Quaternion, Vector
 
 from io_scene_vrm.common import ops, version
+from io_scene_vrm.editor import migration
 from io_scene_vrm.editor.extension import (
     VrmAddonArmatureExtensionPropertyGroup,
     get_armature_extension,
@@ -42,6 +43,43 @@ def assert_vector3_equals(
 
 
 class TestSpringBone1(AddonTestCase):
+    def test_initial_addon_version_migration_preserves_current_gravity_dir(
+        self,
+    ) -> None:
+        context = bpy.context
+
+        bpy.ops.object.add(type="ARMATURE", location=(0, 0, 0))
+        armature = context.object
+        if not armature or not isinstance(armature.data, Armature):
+            raise AssertionError
+
+        ext = get_armature_extension(armature.data)
+        ext.addon_version = ext.INITIAL_ADDON_VERSION
+        ext.spec_version = SPEC_VERSION
+        ext.spring_bone1.initial_automatic_spring_bone_assignment = False
+
+        self.assertEqual(
+            ops.vrm.add_spring_bone1_spring(armature_object_name=armature.name),
+            {"FINISHED"},
+        )
+        self.assertEqual(
+            ops.vrm.add_spring_bone1_spring_joint(
+                armature_object_name=armature.name, spring_index=0
+            ),
+            {"FINISHED"},
+        )
+
+        joint = ext.spring_bone1.springs[0].joints[0]
+        original_gravity_dir = tuple(joint.gravity_dir)
+
+        self.assertTrue(migration.migrate(context, armature.name, heavy_migration=True))
+
+        assert_vector3_equals(
+            Vector(original_gravity_dir),
+            joint.gravity_dir,
+            "Initial addon version migration gravity direction",
+        )
+
     def test_one_joint_extending_in_y_direction(self) -> None:
         context = bpy.context
 


### PR DESCRIPTION
Hi @saturday06, this fixes a spring bone gravity direction override I hit in Blender.

The issue was that initial-version armature extension data could still run the legacy gravity direction migration when the spring bone panel/export path triggered migration. That could rewrite the current VRM1 default/current direction from `(0, 0, -1)` to `(0, 1, 0)`. I also guarded the matching VRM0 migration path.

Changes:
- Skip legacy spring bone gravity fixup when `addon_version == INITIAL_ADDON_VERSION`
- Add a regression test that verifies migration keeps `(0, 0, -1)` intact

Validated with:
- `./tools/format.sh && git diff --exit-code`
- property typing generation + format diff check
- `uv run ruff check`
- targeted Pyright on touched files
- focused regression test
- manual Blender test on the linked extension

Please let me know if this approach looks acceptable. Happy to tweak anything you prefer.