### PR TITLE
fix: guard armature removal for non-deform roots

### DIFF
--- a/src/io_scene_vrm/exporter/vrm1_exporter.py
+++ b/src/io_scene_vrm/exporter/vrm1_exporter.py
@@ -2727,20 +2727,21 @@ class Vrm1Exporter(AbstractBaseVrmExporter):
         if bpy.app.version < (4, 2):
             return False
 
-        if bpy.app.version < (4, 4):
-            # Root bone with non-deform bones returns False
-            # https://github.com/KhronosGroup/glTF-Blender-IO/issues/2394
-            for selected_object in context.selected_objects:
-                if selected_object.type != "ARMATURE":
+        # Root bone with non-deform bones returns False
+        # https://github.com/KhronosGroup/glTF-Blender-IO/issues/2394
+        # https://github.com/KhronosGroup/glTF-Blender-IO/issues/2697
+        # https://github.com/saturday06/VRM-Addon-for-Blender/issues/1227
+        for selected_object in context.selected_objects:
+            if selected_object.type != "ARMATURE":
+                continue
+            armature = selected_object.data
+            if not isinstance(armature, Armature):
+                continue
+            for bone in armature.bones:
+                if bone.parent:
                     continue
-                armature = selected_object.data
-                if not isinstance(armature, Armature):
-                    continue
-                for bone in armature.bones:
-                    if bone.parent:
-                        continue
-                    if not bone.use_deform:
-                        return False
+                if not bone.use_deform:
+                    return False
 
         # Return False if there are vertices with Armature modifier but no weights
         # https://github.com/KhronosGroup/glTF-Blender-IO/issues/2436

--- a/tests/exporter/test_vrm1_exporter.py
+++ b/tests/exporter/test_vrm1_exporter.py
@@ -2,10 +2,17 @@
 
 import sys
 import unittest
+from unittest.mock import MagicMock, patch
 
+import bpy
+from bpy.types import Armature
 from mathutils import Matrix
 
-from io_scene_vrm.exporter.vrm1_exporter import is_identity_matrix
+from io_scene_vrm.exporter.vrm1_exporter import (
+    Vrm1Exporter,
+    is_identity_matrix,
+)
+from tests.util import AddonTestCase
 
 
 class TestVrm1Exporter(unittest.TestCase):
@@ -48,3 +55,29 @@ class TestVrm1Exporter(unittest.TestCase):
         not_identity_off_diagonal = Matrix()
         not_identity_off_diagonal[1][2] = 1e-6
         self.assertFalse(is_identity_matrix(not_identity_off_diagonal))
+
+
+class TestGltfExportArmatureObjectRemove(AddonTestCase):
+    def test_non_deform_root_bone_disables_armature_object_removal(self) -> None:
+        bpy.ops.object.armature_add()
+        armature = bpy.context.object
+        if not armature or not isinstance(armature.data, Armature):
+            raise AssertionError
+
+        # https://github.com/saturday06/VRM-Addon-for-Blender/issues/1227
+        # https://github.com/KhronosGroup/glTF-Blender-IO/issues/2697
+        root_bone = armature.data.bones[0]
+        root_bone.use_deform = False
+
+        mock_bpy = MagicMock(wraps=bpy)
+        mock_bpy.app.version = (5, 0, 0)
+        with patch("io_scene_vrm.exporter.vrm1_exporter.bpy", mock_bpy):
+            self.assertFalse(
+                Vrm1Exporter.gltf_export_armature_object_remove(bpy.context, [])
+            )
+
+        root_bone.use_deform = True
+        with patch("io_scene_vrm.exporter.vrm1_exporter.bpy", mock_bpy):
+            self.assertTrue(
+                Vrm1Exporter.gltf_export_armature_object_remove(bpy.context, [])
+            )


### PR DESCRIPTION
## Bug Fixes

- Keep `export_armature_object_remove` disabled when a selected armature has a non-deform root bone on Blender 4.4 and later.

## Why

Removing that armature can cause Blender's glTF exporter to omit its skin. The exporter already avoids this path on earlier Blender versions; applying the same guard on later versions also protects exports containing another affected armature.

## Verification

- `python3 -m compileall -q src/io_scene_vrm/exporter/vrm1_exporter.py tests/exporter/test_vrm1_exporter.py`
- `git diff --check`

Fixes #1227

Related to #1244
